### PR TITLE
DO NOT MERGE: Working sheet to see WIP on removing versioning. 

### DIFF
--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -27,8 +27,8 @@ var (
 type TypeSyncer interface {
 	// SyncNamespace syncs objects of a namespace for a specific type.
 	SyncNamespace(context.Context, logr.Logger, string) error
-	// Provides the GVK that is handled by the reconciler who implements the interface.
-	GetGVK() schema.GroupVersionKind
+	// Provides the GK that is handled by the reconciler who implements the interface.
+	GetGK() schema.GroupKind
 	// SetMode sets the propagation mode of objects that are handled by the reconciler who implements the interface.
 	// The method also syncs objects in the cluster for the type handled by the reconciler if necessary.
 	SetMode(context.Context, api.SynchronizationMode, logr.Logger) error
@@ -91,9 +91,9 @@ func (f *Forest) AddTypeSyncer(nss TypeSyncer) {
 
 // GetTypeSyncer returns the reconciler for the given GVK or nil if the reconciler
 // does not exist.
-func (f *Forest) GetTypeSyncer(gvk schema.GroupVersionKind) TypeSyncer {
+func (f *Forest) GetTypeSyncer(gk schema.GroupKind) TypeSyncer {
 	for _, t := range f.types {
-		if t.GetGVK() == gvk {
+		if t.GetGK() == gk {
 			return t
 		}
 	}
@@ -366,10 +366,11 @@ func (ns *Namespace) HasOriginalObject(gvk schema.GroupVersionKind, oo string) b
 
 // DeleteOriginalObject deletes an original object from a key string.
 func (ns *Namespace) DeleteOriginalObject(gvk schema.GroupVersionKind, key string) {
-	delete(ns.originalObjects[gvk.GroupKind()], key)
+	gk := gvk.GroupKind()
+	delete(ns.originalObjects[gk], key)
 	// Garbage collection
-	if len(ns.originalObjects[gvk.GroupKind()]) == 0 {
-		delete(ns.originalObjects, gvk.GroupKind())
+	if len(ns.originalObjects[gk]) == 0 {
+		delete(ns.originalObjects, gk)
 	}
 }
 

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -145,7 +145,7 @@ func (f *Forest) GetNamespaceNames() []string {
 type namedNamespaces map[string]*Namespace
 
 // TODO Store source objects by GK in the forest - https://github.com/kubernetes-sigs/multi-tenancy/issues/281
-type objects map[schema.GroupVersionKind]map[string]*unstructured.Unstructured
+type objects map[schema.GroupKind]map[string]*unstructured.Unstructured
 type conditions map[string][]condition
 
 // Local represents conditions that originated from this namespace
@@ -347,16 +347,16 @@ func (ns *Namespace) SetHNSes(hnsnms []string) (diff []string) {
 func (ns *Namespace) SetOriginalObject(obj *unstructured.Unstructured) {
 	gvk := obj.GroupVersionKind()
 	name := obj.GetName()
-	_, ok := ns.originalObjects[gvk]
+	_, ok := ns.originalObjects[gvk.GroupKind()]
 	if !ok {
-		ns.originalObjects[gvk] = map[string]*unstructured.Unstructured{}
+		ns.originalObjects[gvk.GroupKind()] = map[string]*unstructured.Unstructured{}
 	}
-	ns.originalObjects[gvk][name] = obj
+	ns.originalObjects[gvk.GroupKind()][name] = obj
 }
 
 // GetOriginalObject gets an original object from a key string. It returns nil, if the key doesn't exist.
 func (ns *Namespace) GetOriginalObject(gvk schema.GroupVersionKind, key string) *unstructured.Unstructured {
-	return ns.originalObjects[gvk][key]
+	return ns.originalObjects[gvk.GroupKind()][key]
 }
 
 // HasOriginalObject returns if the namespace has an original object.
@@ -366,17 +366,17 @@ func (ns *Namespace) HasOriginalObject(gvk schema.GroupVersionKind, oo string) b
 
 // DeleteOriginalObject deletes an original object from a key string.
 func (ns *Namespace) DeleteOriginalObject(gvk schema.GroupVersionKind, key string) {
-	delete(ns.originalObjects[gvk], key)
+	delete(ns.originalObjects[gvk.GroupKind()], key)
 	// Garbage collection
-	if len(ns.originalObjects[gvk]) == 0 {
-		delete(ns.originalObjects, gvk)
+	if len(ns.originalObjects[gvk.GroupKind()]) == 0 {
+		delete(ns.originalObjects, gvk.GroupKind())
 	}
 }
 
 // GetOriginalObjects returns all original objects in the namespace.
 func (ns *Namespace) GetOriginalObjects(gvk schema.GroupVersionKind) []*unstructured.Unstructured {
 	o := []*unstructured.Unstructured{}
-	for _, obj := range ns.originalObjects[gvk] {
+	for _, obj := range ns.originalObjects[gvk.GroupKind()] {
 		o = append(o, obj)
 	}
 	return o

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -355,17 +355,18 @@ func (ns *Namespace) SetOriginalObject(obj *unstructured.Unstructured) {
 }
 
 // GetOriginalObject gets an original object from a key string. It returns nil, if the key doesn't exist.
-func (ns *Namespace) GetOriginalObject(gvk schema.GroupVersionKind, key string) *unstructured.Unstructured {
-	return ns.originalObjects[gvk.GroupKind()][key]
+func (ns *Namespace) GetOriginalObject(gvk schema.GroupKind, key string) *unstructured.Unstructured {
+	return ns.originalObjects[gvk][key]
 }
 
 // HasOriginalObject returns if the namespace has an original object.
-func (ns *Namespace) HasOriginalObject(gvk schema.GroupVersionKind, oo string) bool {
-	return ns.GetOriginalObject(gvk, oo) != nil
+func (ns *Namespace) HasOriginalObject(gk schema.GroupKind, oo string) bool {
+	return ns.GetOriginalObject(gk, oo) != nil
 }
 
 // DeleteOriginalObject deletes an original object from a key string.
 func (ns *Namespace) DeleteOriginalObject(gvk schema.GroupVersionKind, key string) {
+	// Don't we need the version here to know what we're deleting?
 	gk := gvk.GroupKind()
 	delete(ns.originalObjects[gk], key)
 	// Garbage collection
@@ -375,16 +376,16 @@ func (ns *Namespace) DeleteOriginalObject(gvk schema.GroupVersionKind, key strin
 }
 
 // GetOriginalObjects returns all original objects in the namespace.
-func (ns *Namespace) GetOriginalObjects(gvk schema.GroupVersionKind) []*unstructured.Unstructured {
+func (ns *Namespace) GetOriginalObjects(gk schema.GroupKind) []*unstructured.Unstructured {
 	o := []*unstructured.Unstructured{}
-	for _, obj := range ns.originalObjects[gvk.GroupKind()] {
+	for _, obj := range ns.originalObjects[gk] {
 		o = append(o, obj)
 	}
 	return o
 }
 
 // GetPropagatedObjects returns all original copies in the ancestors.
-func (ns *Namespace) GetPropagatedObjects(gvk schema.GroupVersionKind) []*unstructured.Unstructured {
+func (ns *Namespace) GetPropagatedObjects(gk schema.GroupKind) []*unstructured.Unstructured {
 	o := []*unstructured.Unstructured{}
 	ans := ns.AncestryNames(nil)
 	for _, n := range ans {
@@ -392,7 +393,7 @@ func (ns *Namespace) GetPropagatedObjects(gvk schema.GroupVersionKind) []*unstru
 		if n == ns.name {
 			continue
 		}
-		o = append(o, ns.forest.Get(n).GetOriginalObjects(gvk)...)
+		o = append(o, ns.forest.Get(n).GetOriginalObjects(gk)...)
 	}
 	return o
 }

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -345,13 +345,13 @@ func (ns *Namespace) SetHNSes(hnsnms []string) (diff []string) {
 
 // SetOriginalObject updates or creates the original object in the namespace in the forest.
 func (ns *Namespace) SetOriginalObject(obj *unstructured.Unstructured) {
-	gvk := obj.GroupVersionKind()
+	gk := obj.GroupVersionKind().GroupKind()
 	name := obj.GetName()
-	_, ok := ns.originalObjects[gvk.GroupKind()]
+	_, ok := ns.originalObjects[gk]
 	if !ok {
-		ns.originalObjects[gvk.GroupKind()] = map[string]*unstructured.Unstructured{}
+		ns.originalObjects[gk] = map[string]*unstructured.Unstructured{}
 	}
-	ns.originalObjects[gvk.GroupKind()][name] = obj
+	ns.originalObjects[gk][name] = obj
 }
 
 // GetOriginalObject gets an original object from a key string. It returns nil, if the key doesn't exist.

--- a/incubator/hnc/pkg/stats/stats.go
+++ b/incubator/hnc/pkg/stats/stats.go
@@ -61,10 +61,9 @@ func StopHierConfigReconcile() {
 
 // StartObjReconcile updates the stats for objects with common GK
 // when an object reconciliation starts.
-func StartObjReconcile(gvk schema.GroupVersionKind) {
+func StartObjReconcile(gk schema.GroupKind) {
 	peak.lock.Lock()
 	defer peak.lock.Unlock()
-	gk := gvk.GroupKind()
 	if _, ok := stats.objects[gk]; !ok {
 		stats.objects[gk] = &object{}
 	}
@@ -79,8 +78,7 @@ func StartObjReconcile(gvk schema.GroupVersionKind) {
 
 // StopObjReconcile updates the stats for objects with common GK
 // when an object reconciliation finishes.
-func StopObjReconcile(gvk schema.GroupVersionKind) {
-	gk := gvk.GroupKind()
+func StopObjReconcile(gk schema.GroupKind) {
 	stats.objects[gk].curReconciles.decr()
 }
 


### PR DESCRIPTION
In looking at https://github.com/kubernetes-sigs/multi-tenancy/issues/281 I wonder if we should just leave forest.go lookups by GVK as its the interface we naturally get out of Unstructured and working with the API server. From commit https://github.com/adrianchung/multi-tenancy/commit/c562b8fb99eac9d6794d55b4313e8cf970137e61 I can get a minimal set of changes that allow everything to compile, but then I end up with a forest with an inconsistent mix of lookups by GVK and GK. Future authors will be confused about why we have that distinction.

Past that, when I look at pushing these changes to the consumers of the forest in-memory data structure, it becomes a little clunky to work with due to its interface with with Unstructured, which uses GVK, so either the ObjectReconciler will need to hold a GVK, or adapt it in some way to work with the forest. 

Then there's a question of versioning. What happens if we need to version a new Kind? We could set the version as v1 (hardcode it) as the hub and convert between versions as necessary, but then that information won't be captured in the forest, which would be needed if we ever wanted to what that structure holds. Theoretically there's a path forward (https://book.kubebuilder.io/multiversion-tutorial/conversion-concepts.html seems to be able to support it). 

All that to say.. it's a lot of changes for what I don't think would be generating a lot of value and potentially introducing some confusion. We already have that information coming in from the API and it feels like it's least confusing to just keep GVK and remove the comment. 